### PR TITLE
log https if vite server secure

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,10 +15,13 @@ const Config = {
     | "production"
     | "development",
   vitePort: 5173,
+  viteServerSecure: false,
 };
 
 function getViteHost() {
-  return `http://localhost:${Config.vitePort}`;
+  return `http${Config.viteServerSecure ? "s" : ""}://localhost:${
+    Config.vitePort
+  }`;
 }
 
 function info(msg: string) {
@@ -74,6 +77,8 @@ async function startDevServer() {
 
   const vitePort = server.config.server.port;
   if (vitePort && vitePort !== Config.vitePort) Config.vitePort = vitePort;
+
+  Config.viteServerSecure = Boolean(server.config.server.https);
 
   info(`Vite is listening ${pc.gray(getViteHost())}`);
 


### PR DESCRIPTION
our vite server is using https. it's common for us to open the URL that's logged in our terminal, but vite does not redirect from http to https so I've made it log the correct URL