### PR TITLE
fix(template): add picocolors into devDeps

### DIFF
--- a/create-vite-express/templates/react-ts/package.json
+++ b/create-vite-express/templates/react-ts/package.json
@@ -22,6 +22,7 @@
     "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react": "^3.0.1",
     "nodemon": "^2.0.20",
+    "picocolors": "^1.0.0",
     "vite": "^4.0.4"
   }
 }

--- a/create-vite-express/templates/react/package.json
+++ b/create-vite-express/templates/react/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "^18.0.10",
     "@vitejs/plugin-react": "^3.0.1",
     "nodemon": "^2.0.20",
+    "picocolors": "^1.0.0",
     "vite": "^4.0.4"
   }
 }

--- a/create-vite-express/templates/vanilla-ts/package.json
+++ b/create-vite-express/templates/vanilla-ts/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
+    "picocolors": "^1.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3",
     "vite-express": "*"

--- a/create-vite-express/templates/vanilla/package.json
+++ b/create-vite-express/templates/vanilla/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "nodemon": "^2.0.20",
+    "picocolors": "^1.0.0",
     "vite": "^4.0.4"
   },
   "dependencies": {

--- a/create-vite-express/templates/vue-ts/package.json
+++ b/create-vite-express/templates/vue-ts/package.json
@@ -19,6 +19,7 @@
     "@types/node": "^18.11.18",
     "@vitejs/plugin-vue": "^4.0.0",
     "nodemon": "^2.0.20",
+    "picocolors": "^1.0.0",
     "vite": "^4.0.4",
     "vue-tsc": "^1.0.24"
   }

--- a/create-vite-express/templates/vue/package.json
+++ b/create-vite-express/templates/vue/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.0.0",
     "nodemon": "^2.0.20",
+    "picocolors": "^1.0.0",
     "vite": "^4.0.4"
   }
 }


### PR DESCRIPTION
# Intro
Add picocolors as devDependencies into template


# Why Changed
If you add picocolors into peerDependency section, then you're supposed to add it into devDependency section for all templates. Or you'll get something on terminal like that:
```shell
 WARN  Issues with peer dependencies found
.
└─┬ vite-express
  └── ✕ missing peer picocolors@^1.0.0
Peer dependencies that should be installed:
  picocolors@^1.0.0
```