### PR TITLE
build: add picocolors as dependency instead of peerDep or devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "publish:cli": "bash scripts/publish-cli.sh"
   },
   "dependencies": {
-    "node-fetch": "^2.0.0"
+    "node-fetch": "^2.0.0",
+    "picocolors": "^1.0.0"
   },
   "peerDependencies": {
     "express": "^4.18.2",
-    "vite": "^4.0.0",
-    "picocolors": "^1.0.0"
+    "vite": "^4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.2.0",
@@ -46,7 +46,6 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
     "nodemon": "^2.0.20",
-    "picocolors": "^1.0.0",
     "prettier": "^2.8.3",
     "puppeteer": "^19.6.2",
     "rimraf": "^4.1.2",


### PR DESCRIPTION
# Intro
- add `picocolors` as dependecies instead of as peerDep or devDep