### PR TITLE
Add config flag to determine if Vite's dev server host should be printed to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,11 @@ ViteExpress.config({ /*...*/ });
 
 #### 🔧 Available options
 
-| name     | description                                                                                                                         | default       | valid values                |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------------------------- |
-| mode     | When set to development Vite Dev Server will be utilized, in production app will serve static files built with `vite build` command | `development` | `development`, `production` |
-| vitePort | Port that Vite Dev Server will be listening on                                                                                      | `5173`        | any number                  |
+| name                   | description                                                                                                                            | default       | valid values                |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------------------------- |
+| mode                   | When set to development Vite Dev Server will be utilized, in production app will serve static files built with `vite build` command    | `development` | `development`, `production` |
+| vitePort               | Port that Vite Dev Server will be listening on                                                                                         | `5173`        | any number                  |
+| printViteDevServerHost | When set to true, Vite's dev server host (e.g. `http://localhost:5173`) will be printed to console. Should be used only for debug info | `false`       | boolean                     |
 
 ### `listen(app, port, callback?) => http.Server`
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,9 @@ const Config = {
     | "development",
   vitePort: 5173,
   viteServerSecure: false,
+  printViteDevServerHost: false,
 };
+type ConfigurationOptions = Partial<Omit<typeof Config, "viteServerSecure">>;
 
 function getViteHost() {
   return `${Config.viteServerSecure ? "https" : "http"}://localhost:${
@@ -80,7 +82,8 @@ async function startDevServer() {
 
   Config.viteServerSecure = Boolean(server.config.server.https);
 
-  info(`Vite is listening ${pc.gray(getViteHost())}`);
+  if (Config.printViteDevServerHost)
+    info(`Vite is listening ${pc.gray(getViteHost())}`);
 
   return server;
 }
@@ -112,9 +115,11 @@ async function serveHTML(app: core.Express) {
   }
 }
 
-function config(config: Partial<typeof Config>) {
+function config(config: ConfigurationOptions) {
   if (config.mode) Config.mode = config.mode;
   if (config.vitePort) Config.vitePort = config.vitePort;
+  if (config.printViteDevServerHost)
+    Config.printViteDevServerHost = config.printViteDevServerHost;
 }
 
 async function bind(

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -13,7 +13,7 @@ for (const template of templates) {
     await installYarn();
     it("yarn installed");
 
-    await expectCommandOutput("yarn dev", [/Vite is listening/]);
+    await expectCommandOutput("yarn dev", [/Running in/, /development/]);
     it("dev command works");
 
     await expectCommandOutput("yarn build");


### PR DESCRIPTION
To avoid confusion of two services running as in #33 or #28, we are adding the config flag to specify if the host should be printed. By default it will be set to false - that means that the host will not be printed until you implicitly decide to do it. 