### PR TITLE
Add assetRoot as a configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ ViteExpress.config({ /*...*/ });
 | name                   | description                                                                                                                            | default       | valid values                |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------------------------- |
 | mode                   | When set to development Vite Dev Server will be utilized, in production app will serve static files built with `vite build` command    | `development` | `development`, `production` |
+| assetRoot              | When set, overrides Vite's default asset root behavior (which is typically `process.cwd()`). Helpful if publishing as a package.       | undefined     | any string                  |
 | vitePort               | Port that Vite Dev Server will be listening on                                                                                         | `5173`        | any number                  |
 | printViteDevServerHost | When set to true, Vite's dev server host (e.g. `http://localhost:5173`) will be printed to console. Should be used only for debug info | `false`       | boolean                     |
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ const Config = {
   mode: (NODE_ENV === "production" ? "production" : "development") as
     | "production"
     | "development",
+  assetRoot: undefined,
   vitePort: 5173,
   viteServerSecure: false,
   printViteDevServerHost: false,
@@ -73,6 +74,7 @@ async function serveStatic(app: core.Express) {
 
 async function startDevServer() {
   const server = await Vite.createServer({
+    root: Config.assetRoot,
     clearScreen: false,
     server: { port: Config.vitePort },
   }).then((server) => server.listen());
@@ -91,7 +93,8 @@ async function startDevServer() {
 async function serveHTML(app: core.Express) {
   if (Config.mode === "production") {
     const config = await Vite.resolveConfig({}, "build");
-    const distPath = path.resolve(config.root, config.build.outDir);
+    const root = Config.assetRoot || config.root;
+    const distPath = path.resolve(root, config.build.outDir);
 
     app.use("*", (_, res) => {
       res.sendFile(path.resolve(distPath, "index.html"));
@@ -120,6 +123,7 @@ function config(config: ConfigurationOptions) {
   if (config.vitePort) Config.vitePort = config.vitePort;
   if (config.printViteDevServerHost)
     Config.printViteDevServerHost = config.printViteDevServerHost;
+  if (config.assetRoot) Config.assetRoot = config.assetRoot;
 }
 
 async function bind(

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ const Config = {
   mode: (NODE_ENV === "production" ? "production" : "development") as
     | "production"
     | "development",
-  assetRoot: undefined,
+  assetRoot: undefined as string | undefined,
   vitePort: 5173,
   viteServerSecure: false,
   printViteDevServerHost: false,


### PR DESCRIPTION
Motivation: I'm distributing my server as an npm package to be run with npx. When users run it, currently Vite is looking in their current working directory for assets, where it needs to look relative to the path of the imported file.