### PR TITLE
Add instructions for how to run on a specific host to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,29 @@
 With [Vite](https://vitejs.dev/) you can easily bootstrap your project and just start working without figuring everything out. That's great for front-end apps, but when you want to include server-side into the mix, things get quite complicated. Thanks to **vite-express** you can just as easily start writing full-stack app in seconds.
 
 ```javascript
-const express = require("express");
-const ViteExpress = require("vite-express");
+import express from "express";
+import ViteExpress from "vite-express";
 
 const app = express();
 
 app.get("/message", (_, res) => res.send("Hello from express!"));
 
 ViteExpress.listen(app, 3000, () => console.log("Server is listening..."));
-// or `ViteExpress.listenOnHost(app, 3000, '0.0.0.0', () => console.log("Server is listening..."));`
+```
+
+You can also specify the desired host:
+
+```js
+import express from "express";
+import ViteExpress from "vite-express";
+
+const app = express();
+
+const server = app.listen(3000, "0.0.0.0", () =>
+  console.log("Server is listening...")
+);
+
+ViteExpress.bind(app, server);
 ```
 
 `⚡ vite-express` takes care of

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ const app = express();
 app.get("/message", (_, res) => res.send("Hello from express!"));
 
 ViteExpress.listen(app, 3000, () => console.log("Server is listening..."));
+// or `ViteExpress.listenOnHost(app, 3000, '0.0.0.0', () => console.log("Server is listening..."));`
 ```
 
 `⚡ vite-express` takes care of
@@ -197,7 +198,7 @@ Used to inject necessary middleware into the app, but does not start the listeni
 
 ```js
 const app = express();
-const server = http.createServer(app).listen(3000, () => { 
+const server = http.createServer(app).listen(3000, () => {
    console.log("Server is listening!")
 });
 ViteExpress.bind(app, server);

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ app.get("/message", (_, res) => res.send("Hello from express!"));
 ViteExpress.listen(app, 3000, () => console.log("Server is listening..."));
 ```
 
-You can also specify the desired host:
+You can also bind into the express app, to be able to do things such as specifying custom host address or creating your own server instance (e.g., when you want to use the `https:` protocol).
 
 ```js
 import express from "express";

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,20 +142,10 @@ function listen(app: core.Express, port: number, callback?: () => void) {
   return server;
 }
 
-function listenOnHost(
-  app: core.Express,
-  port: number,
-  host: string,
-  callback?: () => void
-) {
-  const server = app.listen(port, host, () => bind(app, server, callback));
-  return server;
-}
-
 async function build() {
   info("Build starting...");
   await Vite.build();
   info("Build completed!");
 }
 
-export default { config, bind, listen, listenOnHost, build };
+export default { config, bind, listen, build };

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,10 +142,20 @@ function listen(app: core.Express, port: number, callback?: () => void) {
   return server;
 }
 
+function listenOnHost(
+  app: core.Express,
+  port: number,
+  host: string,
+  callback?: () => void
+) {
+  const server = app.listen(port, host, () => bind(app, server, callback));
+  return server;
+}
+
 async function build() {
   info("Build starting...");
   await Vite.build();
   info("Build completed!");
 }
 
-export default { config, bind, listen, build };
+export default { config, bind, listen, listenOnHost, build };


### PR DESCRIPTION
As far as I can tell, currently, there's no way in vite-express to specify the host an app should be running on. This PR proposes a new function `listenOnHost()` that allows the developer to specify the desired host via a new `host` argument.

I went for a new function since I didn't see a way to _(i)_, preserve the nice typings (that we would lose with an `arguments` approach [as in express](https://github.com/expressjs/express/blob/0debedf4f31bb20203da0534719b9b10d6ac9a29/lib/application.js#L635)) and _(ii)_, make the current `listen()` function backward-compatible in a way that calls with and without the new `host` parameter would work.