### PR TITLE
Pass request path into HTML fetch in dev mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,7 @@ async function serveStatic(app: core.Express) {
   } else {
     app.use((req, res, next) => {
       if (isStaticFilePath(req.path)) {
-        fetch(`${getViteHost()}${req.path}`).then((response) => {
+        fetch(new URL(req.path, getViteHost())).then((response) => {
           if (!response.ok) return next();
           res.redirect(response.url);
         });
@@ -100,7 +100,7 @@ async function serveHTML(app: core.Express) {
     app.get("/*", async (req, res, next) => {
       if (isStaticFilePath(req.path)) return next();
 
-      fetch(`${getViteHost()}${req.path}`)
+      fetch(new URL(req.path, getViteHost()))
         .then((res) => res.text())
         .then((content) =>
           content.replace(

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,7 +100,7 @@ async function serveHTML(app: core.Express) {
     app.get("/*", async (req, res, next) => {
       if (isStaticFilePath(req.path)) return next();
 
-      fetch(getViteHost())
+      fetch(`${getViteHost()}${req.path}`)
         .then((res) => res.text())
         .then((content) =>
           content.replace(

--- a/tests/env/subpath/index.html
+++ b/tests/env/subpath/index.html
@@ -7,6 +7,6 @@
     <title>Document</title>
   </head>
   <body>
-    <h1>index</h1>
+    <h1>subpath</h1>
   </body>
 </html>

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -128,3 +128,23 @@ test("Express app with socket.io", async (done) => {
     });
   });
 });
+
+test("Multi-page app", async (done) => {
+  process.chdir(path.join(__dirname, "env"));
+
+  const app = express();
+
+  const server = ViteExpress.listen(app, 3000, async () => {
+    let response = await request(app).get("/");
+    expect(response.text).toMatch(/<h1>index<\/h1>/);
+    response = await request(app).get("/subpath/");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+
+    it("index.html and subpath/index.html are served separately");
+
+    server.close(() => {
+      process.chdir(baseDir);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Request path was not passed properly in HTML fetch call in development mode, which caused Vite multi-page apps not working correctly as described in #39 that should be fixed now.