### PR TITLE
Index.html shouldn't be served by express.static in production

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ async function serveStatic(): Promise<RequestHandler> {
 
     info(`${pc.green(`Serving static files from ${pc.gray(distPath)}`)}`);
 
-    return express.static(distPath);
+    return express.static(distPath, { index: false });
   }
 
   return (req, res, next) => {


### PR DESCRIPTION
The goal of the pull request is to avoid `express.static` serving the index.html file as the file is supposed to be served by app.get('*')

This is a problem because that can mess up authentication middleware.

```
app.use(ViteExpress.static())
app.use(auth());
ViteExpress.listen(app, 3000, () => console.log('Server listening'));
```

In that setup, if we request `/`, express.static is going to return the index.html file by default and bypass the auth middleware. We want to bypass auth for all static files in that setup except index.html