### PR TITLE
Refactor test runner to run each test file in a separate node environment

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 
-import { expectCommandOutput, it, test } from "./lib/runner";
+import { expectCommandOutput, it, run, test } from "./lib/runner";
 import { installYarn } from "./lib/utils";
 
 const baseDir = process.cwd();
@@ -26,3 +26,5 @@ for (const template of templates) {
     done();
   });
 }
+
+run();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 
-import { run } from "./lib/runner";
+import { runTestFile } from "./lib/runner";
 import { isLocalBuild } from "./lib/utils";
 
 if (isLocalBuild()) {
@@ -9,8 +9,7 @@ if (isLocalBuild()) {
   });
 }
 
-require("./server.test");
-require("./templates.test");
-require("./cli.test");
-
-run();
+runTestFile("server.test.ts");
+runTestFile("server.test.ts", { mode: "production" });
+runTestFile("templates.test.ts");
+runTestFile("cli.test.ts");

--- a/tests/lib/runner.ts
+++ b/tests/lib/runner.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { execSync, spawn } from "child_process";
 import pc from "picocolors";
 
 import { getExecutionTimeSeconds, log, wait } from "../lib/utils";
@@ -115,6 +115,16 @@ process.on("unhandledRejection", (e) => {
   printSummary();
   process.exit(1);
 });
+
+export function runTestFile(
+  fileName: string,
+  options?: { mode: "production" | "development" }
+) {
+  execSync(`ts-node tests/${fileName}`, {
+    stdio: "inherit",
+    env: { ...process.env, NODE_ENV: options?.mode ?? "development" },
+  });
+}
 
 function printSummary() {
   log.summary(

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -6,7 +6,7 @@ import { io as SocketIOClient } from "socket.io-client";
 import request from "supertest";
 
 import ViteExpress from "../src/main";
-import { expect, it, test } from "./lib/runner";
+import { expect, it, run, test } from "./lib/runner";
 
 const baseDir = process.cwd();
 
@@ -189,6 +189,8 @@ test("Express app with socket.io", async (done) => {
 });
 
 test("Multi-page app", async (done) => {
+  if (process.env["NODE_ENV"] === "production") return done();
+
   process.chdir(path.join(__dirname, "env"));
 
   const app = express();
@@ -207,3 +209,5 @@ test("Multi-page app", async (done) => {
     });
   });
 });
+
+run();

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import puppeteer from "puppeteer";
 
 import ViteExpress from "../src/main";
-import { expect, it, test } from "./lib/runner";
+import { expect, it, run, test } from "./lib/runner";
 import {
   getButton,
   getButtonText,
@@ -90,3 +90,5 @@ for (const template of templates) {
     });
   });
 }
+
+run();


### PR DESCRIPTION
Each test file from now on will be run in a separate node environment what should fix problems with interference of `vite-express` configuration etc. between each file's tests cases. 
This change makes possible to easily run the same cases for server specific functionalities in production mode without unnecessary duplication of the test cases.