### PR TITLE
Add vite base support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,9 +49,9 @@ async function injectStaticMiddleware(
   app: core.Express,
   middleware: RequestHandler
 ) {
-  const config = await Vite.resolveConfig({}, "build");
-  const base = config.base || "/";
-  app.use(base, middleware);
+  const { base } = await Vite.resolveConfig({}, "build");
+  if (base === "/") app.use(middleware);
+  else app.use(base, middleware);
 
   const stubMiddlewareLayer = app._router.stack.find(
     (layer: { handle?: RequestHandler }) => layer.handle === stubMiddleware

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,9 @@ async function injectStaticMiddleware(
   app: core.Express,
   middleware: RequestHandler
 ) {
-  app.use(middleware);
+  const config = await Vite.resolveConfig({}, "build");
+  const base = config.base || "/";
+  app.use(base, middleware);
 
   const stubMiddlewareLayer = app._router.stack.find(
     (layer: { handle?: RequestHandler }) => layer.handle === stubMiddleware

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,9 +49,9 @@ async function injectStaticMiddleware(
   app: core.Express,
   middleware: RequestHandler
 ) {
-  const { base } = await Vite.resolveConfig({}, "build");
-  if (base === "/") app.use(middleware);
-  else app.use(base, middleware);
+  const config = await Vite.resolveConfig({}, "build");
+  const base = config.base || "/";
+  app.use(base, middleware);
 
   const stubMiddlewareLayer = app._router.stack.find(
     (layer: { handle?: RequestHandler }) => layer.handle === stubMiddleware


### PR DESCRIPTION
For example, we create project in sub dir (for example: `/admin`) we need append base config in vite, like below:

```
export default defineConfig({
  base: '/admin',
  plugins: [react()],
});
```

but the static middleware path in express is incorrect, so we need add prefix from `base` which follow vite config