### PR TITLE
Implement `viteless` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,43 @@ You have these options to achieve that
    ViteExpress.listen(app, 3000, () => console.log("Server is listening..."));
     ```
 
+### ⚡ Viteless mode
+
+ `vite-express` uses Vite even in production to resolve [`vite.config.js`][vite-config] correctly. If you want to be able to run your production app without Vite and all development dependencies, you need to specify custom inline config using `ViteExpress.config({ inlineViteConfig: ... })`.
+
+Valid configuration values used by `vite-express` are [`root`][root], [`base`][base] and [`outDir`][outDir].
+
+- When `inlineViteConfig` is set to `undefined` (by default) Vite is used in production to resolve config file
+- To use viteless mode with the defaults you can set `inlineViteConfig` as `{}`
+
+   ```javascript
+   import express from "express";
+   import ViteExpress from "vite-express";
+
+   ViteExpress.config({ inlineViteConfig: {} })
+   ViteExpress.listen(express(), 3000);
+   ```
+
+- You can also specify any combination of valid parameters
+
+   ```javascript
+   import express from "express";
+   import ViteExpress from "vite-express";
+
+   ViteExpress.config({ 
+      inlineViteConfig: { 
+         base: "/admin", 
+         build: { outDir: "out" }
+      } 
+   });
+
+   ViteExpress.listen(express(), 3000);
+   ```
+
+Be aware that in viteless mode you have two separate sources of truth - `vite.config.js` and your inline configuration, so you need to manually keep them in sync.
+
+Most of the time you are okay with using Vite in production as it's easier, this approach is only recommended if you want to reduce production dependencies.
+
 ## 🤖 Transforming HTML
 
 You can specify transformer function that takes two arguments - HTML as a string and [`Request`][express-request] object - and returns HTML as a string with any string related transformation applied. It can be used to inject your custom metadata on the server-side.
@@ -234,10 +271,20 @@ ViteExpress.config({ /*...*/ });
 
 #### 🔧 Available options
 
-| name        | description                                                                                                                                                                                                                                                                             | default         | valid values                                            |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------- |
-| mode        | When set to development Vite Dev Server will be utilized, in production app will serve static files built with `vite build` command                                                                                                                                                     | `"development"` | `"development"` \| `"production"`                       |
-| transformer | A function used to transform HTML served to the client, useful when you want to inject some metadata on the server. First argument is the HTML that is about to be sent to the client, second is the [`Request`][express-request] object. Needs to return transformed HTML as a string. | `undefined`     | `undefined` \| `(html: string, req: Request) => string` |
+<<<<<<< HEAD
+| name             | description                                                                                                                                                                                                                                                                             | default         | valid values                                            |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------- |
+| mode             | When set to development Vite Dev Server will be utilized, in production app will serve static files built with `vite build` command                                                                                                                                                     | `"development"` | `"development"` \| `"production"`                       |
+| transformer      | A function used to transform HTML served to the client, useful when you want to inject some metadata on the server. First argument is the HTML that is about to be sent to the client, second is the [`Request`][express-request] object. Needs to return transformed HTML as a string. | `undefined`     | `undefined` \| `(html: string, req: Request) => string` |
+| inlineViteConfig | When set to non-undefined value, `vite-express` will be run in [`viteless mode`](#-viteless-mode)                                                                                                                                                                                       | `undefined`     | `undefined` \| `ViteConfig`                             |
+
+```typescript
+type ViteConfig = {
+   root?: string;
+   base?: string;
+   build?: { outDir: string };
+}
+```
 
 ### `listen(app, port, callback?) => http.Server`
 
@@ -305,3 +352,7 @@ ViteExpress.build();
 [MIT](LICENSE)
 
 [express-request]: https://expressjs.com/en/api.html#req
+[vite-config]: https://vitejs.dev/config/
+[root]: https://vitejs.dev/config/shared-options.html#root
+[base]: https://vitejs.dev/config/shared-options.html#base
+[outDir]: https://vitejs.dev/config/build-options.html#build-outdir

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,10 @@ function getTransformedHTML(html: string, req: express.Request) {
   return Config.transformer ? Config.transformer(html, req) : html;
 }
 
+function isRunningViteless() {
+  return Config.inlineViteConfig !== undefined;
+}
+
 async function resolveConfig() {
   if (!Config.inlineViteConfig) {
     const { resolveConfig } = await import("vite");
@@ -163,6 +167,12 @@ async function bind(
     await injectStaticMiddleware(app, vite.middlewares);
     await injectViteIndexMiddleware(app, vite);
   } else {
+    if (isRunningViteless()) {
+      info(
+        `Custom inline config defined, running in ${pc.yellow("viteless")} mode`
+      );
+    }
+
     await injectStaticMiddleware(app, await serveStatic());
     await injectIndexMiddleware(app);
   }

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -44,7 +44,7 @@ for (const template of templates) {
           "<title>Test - $1</title>"
         );
 
-        await wait(100);
+        await wait(200);
 
         let button = await getButton(page);
         await button?.click();
@@ -56,7 +56,7 @@ for (const template of templates) {
           "<title>$1</title>"
         );
 
-        await wait(100);
+        await wait(200);
 
         button = await getButton(page);
         expect(await getButtonText(button)).toBe("count is 0");
@@ -70,11 +70,11 @@ for (const template of templates) {
           await button?.click();
 
           replaceStringInFile(filePath, "count is", "button count is");
-          await wait(100);
+          await wait(200);
           expect(await getButtonText(button)).toBe("button count is 2");
 
           replaceStringInFile(filePath, "button count is", "count is");
-          await wait(100);
+          await wait(200);
           expect(await getButtonText(button)).toBe("count is 2");
 
           it("hot reload works");

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -27,6 +27,8 @@ for (const template of templates) {
     process.chdir(`create-vite-express/templates/${template}`);
     await installYarn();
 
+    await ViteExpress.build();
+
     ViteExpress.config({ inlineViteConfig: undefined });
     await testCase(template, done);
   });


### PR DESCRIPTION
Resolves #62

When you want to avoid using Vite and all its development dependencies (such as plugins) in production mode, you can specify `inlineViteConfig` configuration option to make `vite-express` run in **"viteless"** mode.

Example:
```javascript
import express from "express";
import ViteExpress from "vite-express";

ViteExpress.config({ 
  inlineViteConfig: { 
     base: "/admin", 
     build: { outDir: "out" }
  } 
});

ViteExpress.listen(express(), 3000);
```

By default, when `inlineViteConfig` is `undefined`, Vite is still used in production mode to resolve config file, so you need to have its all dependencies installed.