### PR TITLE
Allow specyfing HTML transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ You have these options to achieve that
 
 ## 🤖 Transforming HTML
 
-You can specify transformer function that takes two arguments - HTML as a string and [`Request`][express-request] object - and apply any string transformation. Can be used to inject your custom metadata on the server-side. Needs to return transformed HTML in form of a string that will be served to the client.
+You can specify transformer function that takes two arguments - HTML as a string and [`Request`][express-request] object - and returns HTML as a string with any string related transformation applied. It can be used to inject your custom metadata on the server-side.
+
+This transformer function is invoked right before sending the HTML to the client in the index-serving middleware that `vite-express` injects at the end of the middleware stack.
 
 Imagine a situation in which your index.html file looks like this
 
@@ -170,6 +172,9 @@ You can then use custom transformer function to replace the HTML comment with an
 ```javascript
 import express from "express";
 import ViteExpress from "vite-express";
+import someMiddleware from "./some/middleware";
+
+const app = express()
 
 function transformer(html: string, req: express.Request) {
    return html.replace(
@@ -178,8 +183,10 @@ function transformer(html: string, req: express.Request) {
    )
 }
 
+app.use(someMiddleware())
+
 ViteExpress.config({ transformer })
-ViteExpress.listen(express(), 3000);
+ViteExpress.listen(app, 3000);
 ```
 
 The HTML served to the client will then look something like this

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 - [📦 Installation \& usage](#-installation--usage)
 - [🚚 Shipping to production](#-shipping-to-production)
+- [🤖 Transforming HTML](#-transforming-html)
 - [🤔 How does it work?](#-how-does-it-work)
 - [📝 Documentation](#-documentation)
 
@@ -147,6 +148,53 @@ You have these options to achieve that
    ViteExpress.listen(app, 3000, () => console.log("Server is listening..."));
     ```
 
+## 🤖 Transforming HTML
+
+You can specify transformer function that takes two arguments - HTML as a string and [`Request`][express-request] object - and apply any string transformation. Can be used to inject your custom metadata on the server-side. Needs to return transformed HTML in form of a string that will be served to the client.
+
+Imagine a situation in which your index.html file looks like this
+
+```html
+<html>
+   <meta>
+      <!-- placeholder -->
+   </meta>
+   <body>
+      <div id="root"></div>
+   </body>
+</html>
+```
+
+You can then use custom transformer function to replace the HTML comment with any string you like. It can be a custom meta tag. You can use request object to extract additional information about request such as requested page.
+
+```javascript
+import express from "express";
+import ViteExpress from "vite-express";
+
+function transformer(html: string, req: express.Request) {
+   return html.replace(
+      "<!-- placeholder -->", 
+      `<meta name="custom" content="${req.baseUrl}"/>`
+   )
+}
+
+ViteExpress.config({ transformer })
+ViteExpress.listen(express(), 3000);
+```
+
+The HTML served to the client will then look something like this
+
+```html
+<html>
+   <meta>
+     <meta name="custom" content="/"/>
+   </meta>
+   <body>
+      <div id="root"></div>
+   </body>
+</html>
+```
+
 ## 🤔 How does it work?
 
 The way `vite-express` works is quite simple. As soon as you invoke `ViteExpress.listen`:
@@ -179,9 +227,10 @@ ViteExpress.config({ /*...*/ });
 
 #### 🔧 Available options
 
-| name | description                                                                                                                         | default       | valid values                |
-| ---- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------- | --------------------------- |
-| mode | When set to development Vite Dev Server will be utilized, in production app will serve static files built with `vite build` command | `development` | `development`, `production` |
+| name        | description                                                                                                                                                                                                                                                                             | default         | valid values                                            |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------- |
+| mode        | When set to development Vite Dev Server will be utilized, in production app will serve static files built with `vite build` command                                                                                                                                                     | `"development"` | `"development"` \| `"production"`                       |
+| transformer | A function used to transform HTML served to the client, useful when you want to inject some metadata on the server. First argument is the HTML that is about to be sent to the client, second is the [`Request`][express-request] object. Needs to return transformed HTML as a string. | `undefined`     | `undefined` \| `(html: string, req: Request) => string` |
 
 ### `listen(app, port, callback?) => http.Server`
 
@@ -247,3 +296,5 @@ ViteExpress.build();
 ## ⚖️ License <!-- omit in toc -->
 
 [MIT](LICENSE)
+
+[express-request]: https://expressjs.com/en/api.html#req

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Imagine a situation in which your index.html file looks like this
 
 ```html
 <html>
-   <meta>
+   <head>
       <!-- placeholder -->
-   </meta>
+   </head>
    <body>
       <div id="root"></div>
    </body>
@@ -193,9 +193,9 @@ The HTML served to the client will then look something like this
 
 ```html
 <html>
-   <meta>
+   <head>
      <meta name="custom" content="/"/>
-   </meta>
+   </head>
    <body>
       <div id="root"></div>
    </body>

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -188,4 +188,37 @@ test("Express app with socket.io", async (done) => {
   });
 });
 
+test("Express app with transformer function", async (done) => {
+  process.chdir(path.join(__dirname, "env"));
+
+  const app = express();
+
+  ViteExpress.config({
+    transformer: (html) => html.replace("<head>", '<head><meta name="test"/>'),
+  });
+
+  const server = ViteExpress.listen(app, 3000, async () => {
+    let response = await request(app).get("/");
+    expect(response.text).toMatch(/<body>/);
+    response = await request(app).get("/route");
+    expect(response.text).toMatch(/<body>/);
+
+    it("html is served correctly");
+
+    expect(response.text).toMatch(/<meta name="test"\/>/);
+
+    it("html is transformed correctly");
+
+    response = await request(app).get("/test.txt");
+    expect(response.text).toBe("Hello from test.txt");
+
+    it("static files are served correctly");
+
+    server.close(() => {
+      process.chdir(baseDir);
+      done();
+    });
+  });
+});
+
 run();


### PR DESCRIPTION
Resolves #56, resolves #58.

In order to address need to transform your HTML to inject any kind of custom markup you can now specify transformer function that takes two arguments, html as a string and an express request object and returns transformed HTML as a string. 

Example:
```javascript
import express from "express";
import ViteExpress from "vite-express";
function transformer(html: string, req: express.Request) {
   return html.replace(
      "<!-- placeholder -->", 
      `<meta name="custom" content="${req.baseUrl}"/>`
   )
}
ViteExpress.config({ transformer })
ViteExpress.listen(express(), 3000);
```