### PR TITLE
Use export assignment syntax in types declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "concurrently -i -P \"sh scripts/dev.sh {1}\" \"yarn build --watch\" --",
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs",
+    "postbuild": "sed -i \"s/export default _default/export = _default/\" dist/main.d.ts",
     "test": "ts-node tests/index.test.ts",
     "test:local": "LOCAL_BUILD_TEST=true ts-node tests/index.test.ts",
     "format": "prettier --write --loglevel silent",


### PR DESCRIPTION
Should resolve #70.

Rollup requires `module` to be set as `ES*`, which means that export assignment is prohibited, so we need to write
```ts
export default { ... };
```  
instead of
```ts
export = { ... };
```
but when using `export default` resulting types sometimes don't work as expected (#70).

As soon as resulting types are modified to use export assignment syntax everything seems to work correctly on both on `commonjs` and `esmodule` setup, so the solution is to use `postbuild` script with `sed` unix utility to replace `export default` with `export = `.