### PR TITLE
Enable multip page

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -201,12 +201,16 @@ async function injectViteIndexMiddleware(
 
     if (isStaticFilePath(req.path)) next();
     else {
-      const template = fs.readFileSync(
-        path.resolve(config.root, "index.html"),
-        "utf8"
-      );
-      const html = await server.transformIndexHtml(req.originalUrl, template);
-      res.send(getTransformedHTML(html, req));
+      try {
+        const template = fs.readFileSync(
+          path.resolve(config.root, "index.html"),
+          "utf8"
+        );
+        const html = await server.transformIndexHtml(req.originalUrl, template);
+        res.send(getTransformedHTML(html, req));
+      } catch (e) {
+        res.sendStatus(404);
+      }
     }
   });
 }
@@ -217,9 +221,15 @@ async function injectIndexMiddleware(app: core.Express) {
   app.use("*", (req, res, next) => {
     if (isIgnoredPath(req.baseUrl, req)) return next();
 
-    const html = fs.readFileSync(path.resolve(distPath, "index.html"), "utf-8");
-
-    res.send(getTransformedHTML(html, req));
+    try {
+      const html = fs.readFileSync(
+        path.resolve(distPath, "index.html"),
+        "utf-8"
+      );
+      res.send(getTransformedHTML(html, req));
+    } catch (e) {
+      res.sendStatus(404);
+    }
   });
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -190,6 +190,10 @@ function isIgnoredPath(path: string, req: express.Request) {
     : Config.ignorePaths(path, req);
 }
 
+function getBasePath(path: string): string {
+  return path.slice(0, path.lastIndexOf("/"));
+}
+
 async function injectViteIndexMiddleware(
   app: core.Express,
   server: ViteDevServer
@@ -202,8 +206,9 @@ async function injectViteIndexMiddleware(
     if (isStaticFilePath(req.path)) next();
     else {
       try {
+        const basePath = getBasePath(req.path);
         const template = fs.readFileSync(
-          path.resolve(config.root, "index.html"),
+          path.join(config.root, basePath, "index.html"),
           "utf8"
         );
         const html = await server.transformIndexHtml(req.originalUrl, template);
@@ -222,8 +227,9 @@ async function injectIndexMiddleware(app: core.Express) {
     if (isIgnoredPath(req.baseUrl, req)) return next();
 
     try {
+      const basePath = getBasePath(req.baseUrl);
       const html = fs.readFileSync(
-        path.resolve(distPath, "index.html"),
+        path.join(distPath, basePath, "index.html"),
         "utf-8"
       );
       res.send(getTransformedHTML(html, req));

--- a/src/main.ts
+++ b/src/main.ts
@@ -227,7 +227,7 @@ async function injectIndexMiddleware(app: core.Express) {
     if (isIgnoredPath(req.baseUrl, req)) return next();
 
     try {
-      const basePath = getBasePath(req.baseUrl);
+      const basePath = getBasePath(req.originalUrl);
       const html = fs.readFileSync(
         path.join(distPath, basePath, "index.html"),
         "utf-8"

--- a/src/main.ts
+++ b/src/main.ts
@@ -199,13 +199,12 @@ async function injectViteIndexMiddleware(
   app.get("/*", async (req, res, next) => {
     if (isIgnoredPath(req.path, req)) return next();
 
-    const template = fs.readFileSync(
-      path.resolve(config.root, "index.html"),
-      "utf8"
-    );
-
     if (isStaticFilePath(req.path)) next();
     else {
+      const template = fs.readFileSync(
+        path.resolve(config.root, "index.html"),
+        "utf8"
+      );
       const html = await server.transformIndexHtml(req.originalUrl, template);
       res.send(getTransformedHTML(html, req));
     }

--- a/tests/env/dist/subpath/index.html
+++ b/tests/env/dist/subpath/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <h1>subpath</h1>
+  </body>
+</html>

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -42,6 +42,13 @@ test("Express app", async (done) => {
 
     it("subpath html is served correctly");
 
+    response = await request(app).get("/nopath/");
+    expect(response.status).toBe(404);
+    response = await request(app).get("/nopath/route");
+    expect(response.status).toBe(404);
+
+    it("no existing indexes response with 404");
+
     response = await request(app).get("/test.txt");
     expect(response.text).toBe("Hello from test.txt");
 
@@ -103,6 +110,13 @@ test("Express app with explicit static middleware", async (done) => {
     expect(response.headers.before).toBe("1");
     expect(response.headers.after).toBe("1");
 
+    response = await request(app).get("/nopath/");
+    expect(response.status).toBe(404);
+    response = await request(app).get("/nopath/route");
+    expect(response.status).toBe(404);
+
+    it("no existing indexes response with 404");
+
     response = await request(app).get("/test.txt");
     expect(response.text).toBe("Hello from test.txt");
 
@@ -156,6 +170,13 @@ test("Express app with custom http server", async (done) => {
     expect(response.text).toMatch(/<h1>subpath<\/h1>/);
 
     it("subpath html is served correctly");
+
+    response = await request(app).get("/nopath/");
+    expect(response.status).toBe(404);
+    response = await request(app).get("/nopath/route");
+    expect(response.status).toBe(404);
+
+    it("no existing indexes response with 404");
 
     response = await request(app).get("/test.txt");
     expect(response.text).toBe("Hello from test.txt");
@@ -241,6 +262,13 @@ test("Express app with transformer function", async (done) => {
 
     it("subpath html is transformed correctly");
 
+    response = await request(app).get("/nopath/");
+    expect(response.status).toBe(404);
+    response = await request(app).get("/nopath/route");
+    expect(response.status).toBe(404);
+
+    it("no existing indexes response with 404");
+
     response = await request(app).get("/test.txt");
     expect(response.text).toBe("Hello from test.txt");
 
@@ -274,6 +302,13 @@ test("Express app with ignored paths", async (done) => {
     expect(response.text).toMatch(/<h1>subpath<\/h1>/);
 
     it("subpath html is served correctly");
+
+    response = await request(app).get("/nopath/");
+    expect(response.status).toBe(404);
+    response = await request(app).get("/nopath/route");
+    expect(response.status).toBe(404);
+
+    it("no existing indexes response with 404");
 
     response = await request(app).get("/ignored");
     expect(response.text).toMatch(/Cannot GET \/ignored/);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -29,11 +29,18 @@ test("Express app", async (done) => {
     it("get api routes work");
 
     response = await request(app).get("/");
-    expect(response.text).toMatch(/<body>/);
+    expect(response.text).toMatch(/<h1>index<\/h1>/);
     response = await request(app).get("/route");
-    expect(response.text).toMatch(/<body>/);
+    expect(response.text).toMatch(/<h1>index<\/h1>/);
 
     it("html is served correctly");
+
+    response = await request(app).get("/subpath/");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+    response = await request(app).get("/subpath/route");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+
+    it("subpath html is served correctly");
 
     response = await request(app).get("/test.txt");
     expect(response.text).toBe("Hello from test.txt");
@@ -86,6 +93,13 @@ test("Express app with explicit static middleware", async (done) => {
 
     it("html is served correctly");
 
+    response = await request(app).get("/subpath/");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+    response = await request(app).get("/subpath/route");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+
+    it("subpath html is served correctly");
+
     expect(response.headers.before).toBe("1");
     expect(response.headers.after).toBe("1");
 
@@ -135,6 +149,13 @@ test("Express app with custom http server", async (done) => {
     expect(response.text).toMatch(/<body>/);
 
     it("html is served correctly");
+
+    response = await request(app).get("/subpath/");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+    response = await request(app).get("/subpath/route");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+
+    it("subpath html is served correctly");
 
     response = await request(app).get("/test.txt");
     expect(response.text).toBe("Hello from test.txt");
@@ -209,6 +230,17 @@ test("Express app with transformer function", async (done) => {
 
     it("html is transformed correctly");
 
+    response = await request(app).get("/subpath/");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+    response = await request(app).get("/subpath/route");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+
+    it("subpath html is served correctly");
+
+    expect(response.text).toMatch(/<meta name="test"\/>/);
+
+    it("subpath html is transformed correctly");
+
     response = await request(app).get("/test.txt");
     expect(response.text).toBe("Hello from test.txt");
 
@@ -235,6 +267,13 @@ test("Express app with ignored paths", async (done) => {
     expect(response.text).toMatch(/<body>/);
 
     it("html is served correctly");
+
+    response = await request(app).get("/subpath/");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+    response = await request(app).get("/subpath/route");
+    expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+
+    it("subpath html is served correctly");
 
     response = await request(app).get("/ignored");
     expect(response.text).toMatch(/Cannot GET \/ignored/);


### PR DESCRIPTION
Hello I recently discovered this project along with Vite and I wanted to use it for a personal application.

Unfortunately, it cannot manage multiple entry points like Vite, as mention here #87.

I have made some investigation and find a way to serve multiple entry points: let's assume this file organization (this is the one picked from Vite documentation: https://vitejs.dev/guide/build.html#multi-page-app):
```
├── package.json
├── vite.config.js
├── index.html
├── main.js
└── nested
    ├── index.html
    └── nested.js
```

+ `http://server:port/`  -> will serve /index.html
+ `http://server:port/plop` -> will also serve /index.html
+ `http://server:port/nested/` -> will serve /nested/index.html
+ `http://server:port/nested/plop` -> will serve /nested/index.html
+ `http://server:port/nested/plop/` -> will try to serve /nested/plop/index.html but will fail

Additionally, I added a way to respond a 404 status if no index is found. For the moment it crashes the dev server.

I completed the tests with all the new cases.

Tell me if you think it can be improved or anything.