### PR TITLE
Mount HTML serving middlewares at config.base 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,6 @@ const Config = {
   transformer: undefined as
     | undefined
     | ((html: string, req: express.Request) => string),
-  ignoreBase: true as boolean,
 };
 
 type ConfigurationOptions = Partial<typeof Config>;
@@ -214,9 +213,9 @@ async function injectViteIndexMiddleware(
 ) {
   const config = await getViteConfig();
 
-  app.use(Config.ignoreBase ? "/" : config.base, async (req, res, next) => {
+  app.use(config.base, async (req, res, next) => {
     if (req.method !== "GET") return next();
-    
+
     if (isIgnoredPath(req.path, req)) return next();
 
     if (isStaticFilePath(req.path)) next();
@@ -235,7 +234,7 @@ async function injectIndexMiddleware(app: core.Express) {
   const distPath = await getDistPath();
   const config = await getViteConfig();
 
-  app.use(Config.ignoreBase ? "/" : config.base, (req, res, next) => {
+  app.use(config.base, (req, res, next) => {
     if (isIgnoredPath(req.path, req)) return next();
 
     const indexPath = findClosestIndexToRoot(req.path, distPath);
@@ -270,7 +269,6 @@ function config(config: ConfigurationOptions) {
   Config.ignorePaths = config.ignorePaths;
   Config.inlineViteConfig = config.inlineViteConfig;
   Config.transformer = config.transformer;
-  if (config.ignoreBase !== undefined) Config.ignoreBase = config.ignoreBase;
 }
 
 async function bind(

--- a/src/main.ts
+++ b/src/main.ts
@@ -215,6 +215,8 @@ async function injectViteIndexMiddleware(
   const config = await getViteConfig();
 
   app.use(Config.ignoreBase ? "/" : config.base, async (req, res, next) => {
+    if (req.method !== "GET") return next();
+    
     if (isIgnoredPath(req.path, req)) return next();
 
     if (isStaticFilePath(req.path)) next();

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -46,25 +46,24 @@ for (const template of templates) {
   test(`Template "${template}" with custom inline config`, async (done) => {
     process.chdir(`create-vite-express/templates/${template}`);
 
+    const base = "/admin";
+
     ViteExpress.config({
-      inlineViteConfig: {
-        base: "/admin",
-        build: { outDir: "out" },
-      },
+      inlineViteConfig: { base, build: { outDir: "out" } },
     });
     await ViteExpress.build();
 
-    await testCase(template, done);
+    await testCase(template, done, base);
   });
 }
 
-const testCase = async (template: string, done: () => void) => {
+const testCase = async (template: string, done: () => void, base = "/") => {
   const server = ViteExpress.listen(express(), 3000, () => {
     const browser = puppeteer.launch();
 
     browser.then(async (browser) => {
       const page = await browser.newPage();
-      await page.goto("http://localhost:3000/admin");
+      await page.goto(`http://localhost:3000${base}`);
 
       it("test set up");
 

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -64,7 +64,7 @@ const testCase = async (template: string, done: () => void) => {
 
     browser.then(async (browser) => {
       const page = await browser.newPage();
-      await page.goto("http://localhost:3000");
+      await page.goto("http://localhost:3000/admin");
 
       it("test set up");
 


### PR DESCRIPTION
IndexMiddleware and ViteIndexMiddleware currently do not take the base into account and always mount at "/". 

Providing developers with the option to decide between mounting both index middlewares at the root or a specified base would enhance flexibility in configuration.