### PR TITLE
emit event when the Vite dev server has finished closing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,13 @@ const app = express();
 const httpServer = ViteExpress.listen(app, 3000, () => console.log("Server is listening!"));
 ```
 
+Emits an event (`vite:close`) when the underlying Vite dev server is finished closing, since that happens asynchronously with closing the Express HTTP server.
+
+```js
+httpServer.on("vite:close", handleViteClose);
+httpServer.close();
+```
+
 ### `async bind(app, server, callback?) => Promise<void>`
 
 Used to inject necessary middleware into the app, but does not start the listening process. Should be used when you want to create your own `http`/`https` server instance manually e.g. when you use `socket.io` library. Same as `listen`, can be invoked at any time because it is async, but it is advised to invoke it when you already registered all routes and middlewares, so that it can correctly hook into the express app.

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ const app = express();
 const httpServer = ViteExpress.listen(app, 3000, () => console.log("Server is listening!"));
 ```
 
-Emits an event (`vite:close`) when the underlying Vite dev server is finished closing, since that happens asynchronously with closing the Express HTTP server.
+When HTTP server has been closed using the `close()` method, vite-express also closes the Vite dev server asynchronously. After that, a `vite:close` event is emitted so you can listen to that event to have a guarantee that all server resources were freed.
 
 ```js
 httpServer.on("vite:close", handleViteClose);

--- a/src/main.ts
+++ b/src/main.ts
@@ -259,7 +259,10 @@ async function startServer(server: http.Server | https.Server) {
     }),
   );
 
-  server.on("close", () => vite.close());
+  server.on("close", async () => {
+    await vite.close()
+    server.emit("vite-dev-server:closed");
+  });
 
   return vite;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -261,7 +261,7 @@ async function startServer(server: http.Server | https.Server) {
 
   server.on("close", async () => {
     await vite.close()
-    server.emit("vite-dev-server:closed");
+    server.emit("vite-dev-server:exit");
   });
 
   return vite;

--- a/src/main.ts
+++ b/src/main.ts
@@ -261,7 +261,7 @@ async function startServer(server: http.Server | https.Server) {
 
   server.on("close", async () => {
     await vite.close()
-    server.emit("vite-dev-server:exit");
+    server.emit("vite:close");
   });
 
   return vite;


### PR DESCRIPTION
## Currently

The Vite dev server instance is closed when I call the close method on the server instance returned by `listen`, however, the dev server uses resources (e.g. a port for the WebSocket) and those resources aren't freed synchronously.

## Proposal

Emit another event when the dev server has finished closing so that the caller of `listen` knows when it's safe to use those resources (e.g. by calling `listen` again)

## Context/Motivation

I want to have my backend be fully reloaded when its source code changes. Perhaps there are other ways to achieve this, but re-invoking `listen` and getting a new Server instance seems the most intuitive to me, right now.

Note: I spent a few minutes trying to get the build/CI for the project working but ended up testing these changes by copy/pasting main.ts into my project. These changes worked for me. Any guidance on how to do this properly would be appreciated! Also thanks for sharing this project!