### PR TITLE
Make Vite middleware use current server for HMR WebSocket

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -255,7 +255,10 @@ async function startServer(server: http.Server | https.Server) {
     mergeConfig(isUsingViteResolvedConfig ? {} : config, {
       clearScreen: false,
       appType: "custom",
-      server: { middlewareMode: true },
+      server: {
+        middlewareMode: true,
+        hmr: { server },
+      },
     }),
   );
 


### PR DESCRIPTION
I wanted to use a server with HTTPS and I observed that the HMR feature of viteJS was not working because the WebSocket connection did not work.

I submit an issue for this problem with a reproduction link : https://github.com/vitejs/vite/issues/15297
I was suggested to use the `hmr` option for the vite middleware in order to use the exact same server for the content serving and the websocket.

The solution allowed me to use https during development.

The other benefit is that no other port is used. Without this option Vite use the hardcoded 24678 port for the WebSocket.