### PR TITLE
Fix build after dependencies update

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,5 +7,5 @@ export default {
     format: "cjs",
   },
   external: ["express", "vite", "node-fetch", "fs", "path", "picocolors"],
-  plugins: [typescript({ module: "ESNext" })],
+  plugins: [typescript({ module: "ESNext", include: "src/main.ts" })],
 };


### PR DESCRIPTION
After some investigation on this issue #99, I found a fix on the rollup configuration.

I added an `include` field on the typescript plugin to point to the `main.ts`.

I am not really satisfied of this solution as I think the problem come from either @rollup/plugin-typescript, or picocolors.

However it should fix the build.