### PR TITLE
Fix module resolution errors

### DIFF
--- a/create-vite-express/templates/react-ts/src/client/tsconfig.json
+++ b/create-vite-express/templates/react-ts/src/client/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "ESNext",
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx"
   }
 }

--- a/create-vite-express/templates/vanilla-ts/src/client/tsconfig.json
+++ b/create-vite-express/templates/vanilla-ts/src/client/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "ESNext"
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
   }
 }

--- a/create-vite-express/templates/vue-ts/src/client/tsconfig.json
+++ b/create-vite-express/templates/vue-ts/src/client/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "ESNext"
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
   }
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -22,6 +22,16 @@ for (const template of templates) {
     await expectCommandOutput("yarn start", [/Running in/, /production/]);
     it("production build works");
 
+    // Vue needs Volar extension to support .vue files correctly in TS LS
+    // https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin
+    // so it's easier to just ignore it
+    if (template.includes("-ts") && !template.includes("vue")) {
+      await expectCommandOutput(
+        "yarn tsc -p src/client/tsconfig.json --noEmit",
+      );
+      it("client passes typecheck");
+    }
+
     process.chdir(baseDir);
     done();
   });


### PR DESCRIPTION
Fixes #104 

There is a problem with testing Vue typescript configuration due to TypeScript Language Server not recognizing `.vue` files out of the box without Volar extension, so it is ignored in tests. Still better idea than to include shims like 

```ts
declare module '*.vue';
```

that break navigation capabilities.