### PR TITLE
Instead of exclusively serving and transforming index files, consider serving and transforming every HTML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Contributors: [@elturpin](https://github.com/elturpin), [@patreeceeo](https://gi
 
 ## 0.11.1 (2023-11-17)
 
-- Mount middlewares that serve HTML at `config.root` instead of `/` ([#91](https://github.com/szymmis/vite-express/pull/91))
+- Mount middlewares that serve HTML at `config.base` instead of `/` ([#91](https://github.com/szymmis/vite-express/pull/91))
 
 Contributors: [@rmhaiderali](https://github.com/rmhaiderali)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,10 +47,6 @@ function info(msg: string) {
   );
 }
 
-function isStaticFilePath(path: string) {
-  return path.match(/(\.\w+$)|@vite|@id|@react-refresh/);
-}
-
 async function getTransformedHTML(html: string, req: express.Request) {
   return Config.transformer ? Config.transformer(html, req) : html;
 }
@@ -226,22 +222,19 @@ async function injectViteIndexMiddleware(
 
     if (isIgnoredPath(req.path, req)) return next();
 
-    if (isStaticFilePath(req.path)) next();
-    else {
-      const indexPath = findClosestIndexToRoot(req.path, config.root);
-      if (indexPath === undefined) return next();
+    const indexPath = findClosestIndexToRoot(req.path, config.root);
+    if (indexPath === undefined) return next();
 
-      const template = fs.readFileSync(indexPath, "utf8");
-      let html = await server.transformIndexHtml(req.originalUrl, template);
+    const template = fs.readFileSync(indexPath, "utf8");
+    let html = await server.transformIndexHtml(req.originalUrl, template);
 
-      try {
-        html = await getTransformedHTML(html, req);
-        res.send(html);
-      } catch (e) {
-        console.error(e);
-        res.status(500);
-        return next();
-      }
+    try {
+      html = await getTransformedHTML(html, req);
+      res.send(html);
+    } catch (e) {
+      console.error(e);
+      res.status(500);
+      return next();
     }
   });
 }


### PR DESCRIPTION
This pull request addresses two main issues. 

Firstly, it resolves the problem of not serving HTML files in dev mode when the request explicitly includes filenames like /index.html or /main.html. 

Secondly, in production mode, when specifically requesting /index.html, the HTML transformer function was being skipped, potentially causing issues as described in issue #109.

Additionally, this pull request will enable users to use the .htm extension in addition to .html. After applying this pull request, transformer functions can now be used with any file ending with .html or .htm.

This is achieved by skipping files with .htm or .html extensions in the Static Middleware Function to ensure proper serving and transformation of these files.