### PR TITLE
Fix subpath script import from subpath html

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -104,7 +104,9 @@ async function resolveConfig(): Promise<ViteConfig> {
         ),
       );
     }
-  } catch (e) {}
+  } catch (e) {
+    /* empty */
+  }
 
   try {
     const config = fs.readFileSync(getViteConfigPath(), "utf8");

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,7 +234,11 @@ async function injectViteHTMLMiddleware(
     if (templateFilePath === undefined) return next();
 
     const template = fs.readFileSync(templateFilePath, "utf8");
-    let html = await server.transformIndexHtml(req.originalUrl, template);
+    let html = await server.transformIndexHtml(
+      templateFilePath,
+      template,
+      req.originalUrl,
+    );
 
     try {
       html = await getTransformedHTML(html, req);

--- a/tests/envs/basic/subpath/index.html
+++ b/tests/envs/basic/subpath/index.html
@@ -8,5 +8,6 @@
   </head>
   <body>
     <h1>subpath</h1>
+    <script type="module" src="./script.js"></script>
   </body>
 </html>

--- a/tests/envs/basic/subpath/script.js
+++ b/tests/envs/basic/subpath/script.js
@@ -1,0 +1,1 @@
+console.log("script imported");

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -47,10 +47,15 @@ describe.each(["development", "production"] as const)(
       test("subpath html is served correctly", async () => {
         const spyConsolError = vi.spyOn(console, "error");
         let response = await request(app).get("/subpath/");
-        expect(spyConsolError).not.toHaveBeenCalled();
         expect(response.text).toMatch(/<h1>subpath<\/h1>/);
         response = await request(app).get("/subpath/route");
         expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+        // FIXME: Find a better way to do this
+        // Assert that Vite is not printing pre-transform error to console
+        // when resolving subpath/script.js as a relative import
+        //
+        // https://github.com/szymmis/vite-express/pull/114
+        expect(spyConsolError).not.toHaveBeenCalled();
         vi.restoreAllMocks();
       });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -5,7 +5,7 @@ import path from "path";
 import * as SocketIO from "socket.io";
 import { io as SocketIOClient } from "socket.io-client";
 import request from "supertest";
-import { beforeAll, describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 
 import ViteExpress from "../src/main";
 
@@ -45,10 +45,13 @@ describe.each(["development", "production"] as const)(
       });
 
       test("subpath html is served correctly", async () => {
+        const spyConsolError = vi.spyOn(console, "error");
         let response = await request(app).get("/subpath/");
+        expect(spyConsolError).not.toHaveBeenCalled();
         expect(response.text).toMatch(/<h1>subpath<\/h1>/);
         response = await request(app).get("/subpath/route");
         expect(response.text).toMatch(/<h1>subpath<\/h1>/);
+        vi.restoreAllMocks();
       });
 
       test("fallback to closest index towards root", async () => {


### PR DESCRIPTION
I recently discovered that if an html file located in a sub-path of the root imported a script in the sub-path using relative path, vite server would complain that the script was not found because he was searching at the root.

*i.e.* if we got `/subpath/index.html` while the a script was at `/subpath/script.js`
```html
<script type="module" src="./script.js"></script>
```
vite would search `/script.js`.

I add test case to give a complete example in the basic env.

I manage to understand that the problem comes from how the vite middleware is done and how the `transformIndexHtml` of vite is used. From the code of vite (https://github.com/vitejs/vite/blob/6c4bf266a0bcae8512f6daf99dff57a73ae7bcf6/packages/vite/src/node/server/middlewares/indexHtml.ts#L435) I discovered that we can give more context on what is the real path of the template so that the path given inside the template take the right reference.

For the tests, I am not really satisfied of my solution. The problem is that the server manage to serve what it must serve, their is just an error log from vite that tells their is something wrong. So I spy on the `console.error` calls. I do not now if their is something better to do.