### PR TITLE
Respect HMR options from Vite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,11 @@ type ViteConfig = {
    root?: string;
    base?: string;
    build?: { outDir: string };
+   server?: { hmr?: boolean | HmrOptions };
 }
 ```
+
+You can read more about `HmrOptions` in Vite [docs](https://vitejs.dev/config/server-options.html#server-hmr).
 
 ### `listen(app, port, callback?) => http.Server`
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.5",
     "@types/express": "^4.17.21",
+    "@types/mime": "^4.0.0",
     "@types/node": "^20.10.0",
     "@types/node-fetch": "^2.6.9",
     "@types/socket.io": "^3.0.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,12 +5,13 @@ import http from "http";
 import https from "https";
 import path from "path";
 import pc from "picocolors";
-import type { ViteDevServer } from "vite";
+import type { HmrOptions, ViteDevServer } from "vite";
 
 type ViteConfig = {
   root: string;
   base: string;
   build: { outDir: string };
+  server?: { hmr?: boolean | HmrOptions };
 };
 
 const _State = {
@@ -295,7 +296,7 @@ async function startServer(server: http.Server | https.Server) {
       appType: "custom",
       server: {
         middlewareMode: true,
-        hmr: { server },
+        hmr: config.server?.hmr ?? { server },
       },
     }),
   );
@@ -350,4 +351,11 @@ async function build() {
   info("Build completed!");
 }
 
-export default { config, bind, listen, build, static: () => stubMiddleware, getViteConfig };
+export default {
+  config,
+  bind,
+  listen,
+  build,
+  static: () => stubMiddleware,
+  getViteConfig,
+};

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -208,7 +208,7 @@ describe.each(TEMPLATES)(`Template $name`, (template) => {
           replaceStringInFile(
             path.join(tmpdir, "test", "custom.config.js"),
             "plugins:",
-            "base: '/test', plugins:",
+            "server: { hmr: { port: 3001 } }, base: '/test', plugins:",
           );
         } else {
           fs.writeFileSync(
@@ -218,6 +218,7 @@ describe.each(TEMPLATES)(`Template $name`, (template) => {
 
             export default defineConfig({
               base: '/test',
+              server: { hmr: { port: 3001 } }
             });
 
             `,

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,7 +821,7 @@
   resolved "https://registry.yarnpkg.com/@types/methods/-/methods-1.1.4.tgz#d3b7ac30ac47c91054ea951ce9eed07b1051e547"
   integrity sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==
 
-"@types/mime@*":
+"@types/mime@*", "@types/mime@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-4.0.0.tgz#b5f8a75697ac775ecf1daaea9bfb91cde065b397"
   integrity sha512-5eEkJZ/BLvTE3vXGKkWlyTSUVZuzj23Wj8PoyOq2lt5I3CYbiLBOPb3XmCW6QcuOibIUE6emHXHt9E/F/rCa6w==


### PR DESCRIPTION
Solves #122.

Basically, what this PR does it adds support for respecting hmr options from Vite. Before `vite-express` set hmr to the server object and it ignored any custom options that user provided. Right now when there is custom hmr setting `vite-express` just passes it down the line. This is usefull when you want to have for example a WS server listening on port 3000 and you need to tell Vite to listen on port 3001 instead.