### PR TITLE
Fix issue where passing the `server` config disables inline config

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -298,10 +298,9 @@ async function startServer(server: http.Server | https.Server) {
   const { createServer, mergeConfig } = await import("vite");
 
   const config = await getViteConfig();
-  const isUsingViteResolvedConfig = Object.entries(config).length > 3;
 
   const vite = await createServer(
-    mergeConfig(isUsingViteResolvedConfig ? {} : config, {
+    mergeConfig(config, {
       configFile: Config.viteConfigFile,
       clearScreen: false,
       appType: "custom",

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,9 +298,10 @@ async function startServer(server: http.Server | https.Server) {
   const { createServer, mergeConfig } = await import("vite");
 
   const config = await getViteConfig();
+  const isUsingViteResolvedConfig = "assetsInclude" in config;
 
   const vite = await createServer(
-    mergeConfig(config, {
+    mergeConfig(isUsingViteResolvedConfig ? {} : config, {
       configFile: Config.viteConfigFile,
       clearScreen: false,
       appType: "custom",


### PR DESCRIPTION
There is a check that checks whether the config is resolved through vite or not. The problem is that the check only checks for an object length of greater than 3.

By default, passing inline vite config will have a minimum of 3 because of the default config. See: https://github.com/Vija02/vite-express/blob/a62ab580b9a9944aceecc0fa1ebe63090756711b/src/main.ts#L95

Those config are: `root`, `base`, and `build`. This means that if the user passes the `server` config, this check will be wrong.

~~But the question is why do we need that in the first place? The `mergeConfig` should resolve any inconsistency. And if not, the check should be more robust. I've removed the check and confirmed that it works fine for inline configuration but I've not tested it with the other 2 methods.~~

I've updated it to check for the `assetsInclude` property. From vite's documentation, this property will exist when it is a `ResolvedConfig`
![image](https://github.com/user-attachments/assets/d33524e4-9c58-4593-8b48-6e0dceb423b0)
