### PR TITLE
Replaced express.static with expressStaticGzip

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "publish:cli": "bash scripts/publish-cli.sh"
   },
   "dependencies": {
+    "express-static-gzip": "^2.1.7",
     "picocolors": "^1.0.0"
   },
   "devDependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,10 @@ import http from "http";
 import https from "https";
 import path from "path";
 import pc from "picocolors";
-import { ServeStaticOptions } from "serve-static";
+import expressStaticGzip, {
+  ExpressStaticGzipOptions,
+} from "express-static-gzip";
+
 import type { HmrOptions, ViteDevServer } from "vite";
 
 type ViteConfig = {
@@ -23,7 +26,7 @@ enum Verbosity {
 
 const _State = {
   viteConfig: undefined as ViteConfig | undefined,
-  staticOptions: undefined as ServeStaticOptions | undefined,
+  staticOptions: undefined as ExpressStaticGzipOptions | undefined,
 };
 
 function clearState() {
@@ -174,7 +177,7 @@ async function serveStatic(): Promise<RequestHandler> {
     info(`${pc.green(`Serving static files from ${pc.gray(distPath)}`)}`);
   }
 
-  return express.static(distPath, { index: false, ..._State.staticOptions });
+  return expressStaticGzip(distPath, { index: false, ..._State.staticOptions });
 }
 
 const stubMiddleware: RequestHandler = (req, res, next) => next();
@@ -368,7 +371,7 @@ export default {
   bind,
   listen,
   build,
-  static: (options?: ServeStaticOptions) => {
+  static: (options?: ExpressStaticGzipOptions) => {
     _State.staticOptions = options;
     return stubMiddleware;
   },


### PR DESCRIPTION
I needed to control my compressed files and the order in which they are served to the client. In this commit, I've replaced express.static with expressStaticGzip, which provides more options for customization and control over which compressed files to serve. Here is a functional example:

```javascript
ViteExpress.static({
	enableBrotli: true,
	orderPreference: ['zstd', 'br', 'gz'],
	customCompressions: [{ encodingName: 'zstd', fileExtension: 'zst' }],
	index: false,
});
```

I'm using a temporary version I uploaded to npm (@je4ngomes/vite-express) to test this. In case this gets accepted it would be necessary to update the README.md file.

I appreciate you maintaining this package :)